### PR TITLE
Add timeline 201705-201708

### DIFF
--- a/2017-09/timeline.md
+++ b/2017-09/timeline.md
@@ -65,19 +65,7 @@
 ## 2017-08-28
 * [OSS Gate東京ミートアップ2017-08-28](https://oss-gate.doorkeeper.jp/events/63053) を開催予定
 * 開催の狙い
-* Doorkeeper 申込状況
-  * 開発者枠
-  3名
-  * 駆け出し開発者枠
-  5名
 
 ## 2017-09-02
 * [OSS Gate東京ワークショップ for 高専 2017-09-02](https://oss-gate.doorkeeper.jp/events/63111) を開催予定
 * 開催の狙い
-* Doorkeeper 申込状況
-  * ビギナー（高専生、学生）
-  4名
-  * ビギナー（上記以外）
-  3名
-  * サポーター
-  5名

--- a/2017-09/timeline.md
+++ b/2017-09/timeline.md
@@ -1,31 +1,83 @@
 # タイムライン 2017年5月~2017年8月
 
-## yyyy-mm-dd 
-* [イベント名](URL)
-* 概要
+## 2017-05-22
+* [OSS Gate東京ミートアップ2017-05-22](https://oss-gate.doorkeeper.jp/events/60514) を開催
 * 開催の狙い
 * Doorkeeper 申込履歴
-  * ロール1
-  ??名
-  * ロール2
-  ??名
+  * 開発者枠
+  2名
+  * 駆け出し開発者枠
+  3名
 
-## yyyy-mm-dd 
-* [イベント名](URL)
-* 概要
+## 2017-05-27
+* [OSS Gate東京ワークショップ2017-05-27](https://oss-gate.doorkeeper.jp/events/59202) を開催
 * 開催の狙い
 * Doorkeeper 申込履歴
-  * ロール1
-  ??名
-  * ロール2
-  ??名
+  * ビギナー (参加経験アリ)
+  1名
+  * ビギナー (参加経験アリ)
+  13名
+  * サポーター
+  4名
 
-## yyyy-mm-dd 
-* [イベント名](URL)
-* 概要
+## 2017-06-19
+* [OSS Gate東京ミートアップ2017-06-19](https://oss-gate.doorkeeper.jp/events/61030) を開催
 * 開催の狙い
 * Doorkeeper 申込履歴
-  * ロール1
-  ??名
-  * ロール2
-  ??名
+  * 開発者枠
+  6名
+  * 駆け出し開発者枠
+  6名
+
+## 2017-06-29
+* [OSS Gate東京ワークショップ for Mastodon in ピクシブ 2017-06-29](https://oss-gate.doorkeeper.jp/events/61807) を開催
+* 開催の狙い
+* Doorkeeper 申込履歴
+  * ビギナー (参加経験アリ)
+  1名
+  * ビギナー (参加経験アリ)
+  6名
+  * サポーター
+  5名
+
+## 2017-07-13
+* [OSS Gate東京ミートアップ2017-07-13](https://oss-gate.doorkeeper.jp/events/62157) を開催
+* 開催の狙い
+* Doorkeeper 申込履歴
+  * 開発者枠
+  5名
+  * 駆け出し開発者枠
+  4名
+
+## 2017-07-29
+* [OSS Gate東京ワークショップ2017-07-29](https://oss-gate.doorkeeper.jp/events/61378) を開催
+* 開催の狙い
+* Doorkeeper 申込履歴
+  * ビギナー (参加経験アリ)
+  3名
+  * ビギナー (参加経験アリ)
+  16名
+  * サポーター
+  5名
+  * レポーター
+  1名
+
+## 2017-08-28
+* [OSS Gate東京ミートアップ2017-08-28](https://oss-gate.doorkeeper.jp/events/63053) を開催予定
+* 開催の狙い
+* Doorkeeper 申込状況
+  * 開発者枠
+  3名
+  * 駆け出し開発者枠
+  5名
+
+## 2017-09-02
+* [OSS Gate東京ワークショップ for 高専 2017-09-02](https://oss-gate.doorkeeper.jp/events/63111) を開催予定
+* 開催の狙い
+* Doorkeeper 申込状況
+  * ビギナー（高専生、学生）
+  4名
+  * ビギナー（上記以外）
+  3名
+  * サポーター
+  5名


### PR DESCRIPTION
## 追加したもの
* 2017年5月から2017年8月のイベント開催状況を追加
* Doorkeeperのイベントから追加
* 東京の開催のみを追加
* 数が多いのと、実際、各地域のふりかえりはできない
* ファイル名も tokyo としたほうが良い気がしている

## 確認して欲しいこと
* よくリンクを間違うのでおねしゃす。。。:pray:

## 懸念点
* 開催の狙いに 試すこと を入れると良いと思ってるんですが、どなたか、覚えている範囲で追記してもらえるとうれしいです